### PR TITLE
setup.py: Version shouldn't be prefixed with 'v'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='ocrd-anybaseocr',
-    version='v0.0.1',
+    version='0.0.1',
     author="DFKI",
     author_email="Saqib.Bukhari@dfki.de, Mohammad_mohsin.reza@dfki.de",
     url="https://github.com/mjenckel/LAYoutERkennung",


### PR DESCRIPTION
Otherwise python complains:

```
/data/monorepo/venv3.6/lib/python3.6/site-packages/setuptools/dist.py:470: UserWarning: Normalizing 'v0.0.1' to '0.0.1'
  normalized_version,
```