### PR TITLE
fix syntax error in ocrd-tool.json

### DIFF
--- a/ocrd_anybaseocr/ocrd-tool.json
+++ b/ocrd_anybaseocr/ocrd-tool.json
@@ -148,7 +148,8 @@
       "parameters": {        
         "block_segmentation_model":   { "type": "string","default":"mrcnn/", "required": false, "description": "Path to block segmentation Model"},
         "block_segmentation_weights": { "type": "string","default":"mrcnn/block_segmentation_weights.h5",  "required": false, "description": "Path to model weights"},
-         "operation_level": {"type": "string", "enum": ["page","region", "line"], "default": "page","description": "PAGE XML hierarchy level to operate on"}
-    }       
+        "operation_level": {"type": "string", "enum": ["page","region", "line"], "default": "page","description": "PAGE XML hierarchy level to operate on"}
+      }       
+    }
   }
 }


### PR DESCRIPTION
Missing curly brace

BTW you can test whether your ocrd-tool.json is valid by

```sh
ocrd ocrd-tool ocrd-tool.json validate
```