### PR TITLE
crop: add 'padding' parameter (default to 10px)

### DIFF
--- a/ocrd_anybaseocr/cli/ocrd_anybaseocr_cropping.py
+++ b/ocrd_anybaseocr/cli/ocrd_anybaseocr_cropping.py
@@ -54,7 +54,8 @@ from ocrd_utils import (
     MIMETYPE_PAGE, 
     coordinates_for_segment,
     bbox_from_points,
-    points_from_polygon
+    points_from_polygon,
+    polygon_from_bbox
 )
 from ocrd_models.ocrd_page import (
     CoordsType,
@@ -64,7 +65,6 @@ from ocrd_models.ocrd_page import (
 from ocrd_models.ocrd_page_generateds import BorderType
 
 TOOL = 'ocrd-anybaseocr-crop'
-
 
 class OcrdAnybaseocrCropper(Processor):
 
@@ -406,12 +406,6 @@ class OcrdAnybaseocrCropper(Processor):
         if len(textarea) > 0:
             textarea = sorted(textarea, key=lambda x: (
                 (x[2]-x[0])*(x[3]-x[1])), reverse=True)
-            # print textarea
-            x1, y1, x2, y2 = textarea[0]
-            x1 = x1-20 if x1 > 20 else 0
-            x2 = x2+20 if x2 < width-20 else width
-            y1 = y1-40 if y1 > 40 else 0
-            y2 = y2+40 if y2 < height-40 else height
 
             #self.save_pf(base, [x1, y1, x2, y2])
 
@@ -424,10 +418,8 @@ class OcrdAnybaseocrCropper(Processor):
 
         LOG = getLogger('OcrdAnybaseocrCropper')
 
-        oplevel = self.parameter['operation_level']
         for (n, input_file) in enumerate(self.input_files):
             page_id = input_file.pageId or input_file.ID
-
             LOG.info("INPUT FILE %i / %s", n, page_id)
 
             pcgts = page_from_file(self.workspace.download_file(input_file))
@@ -447,12 +439,7 @@ class OcrdAnybaseocrCropper(Processor):
                 feature_filter='cropped',
                 feature_selector='binarized') # should also be deskewed
 
-            if oplevel == "page":
-                self._process_segment(
-                    page_image, page, page_coords, page_id, input_file, n)
-            else:
-                raise Exception(
-                    'Operation level %s, but should be "page".', oplevel)
+            self._process_page(page, page_image, page_coords, input_file)
             file_id = make_file_id(input_file, self.output_file_grp)
             pcgts.set_pcGtsId(file_id)
             self.workspace.add_file(
@@ -464,7 +451,7 @@ class OcrdAnybaseocrCropper(Processor):
                 content=to_xml(pcgts).encode('utf-8')
             )
 
-    def _process_segment(self, page_image, page, page_xywh, page_id, input_file, n):
+    def _process_page(self, page, page_image, page_xywh, input_file):
         img_array = ocrolib.pil2array(page_image)
 
         # Check if image is RGB or not #FIXME: check not needed anymore?
@@ -492,31 +479,27 @@ class OcrdAnybaseocrCropper(Processor):
             else:
                 min_x, min_y, max_x, max_y = textarea[0]
         elif len(textarea) == 1 and (height*width*0.5 < (abs(textarea[0][2]-textarea[0][0]) * abs(textarea[0][3]-textarea[0][1]))):
-            x1, y1, x2, y2 = textarea[0]
-            x1 = x1-20 if x1 > 20 else 0
-            x2 = x2+20 if x2 < width-20 else width
-            y1 = y1-40 if y1 > 40 else 0
-            y2 = y2+40 if y2 < height-40 else height
-
             min_x, min_y, max_x, max_y = textarea[0]
         else:
             min_x, min_y, max_x, max_y = self.select_borderLine(
                 img_array_rr, lineDetectH, lineDetectV)
 
-        border_polygon = [[min_x, min_y], [max_x, min_y], [max_x, max_y], [min_x, max_y]]
+        left = max(0, min_x - self.parameter['padding'])
+        top = max(0, min_y - self.parameter['padding'])
+        right = min(page_image.width, max_x + self.parameter['padding'])
+        bottom = min(page_image.height, max_y + self.parameter['padding'])
+        border_polygon = polygon_from_bbox(left, top, right, bottom)
         border_polygon = coordinates_for_segment(border_polygon, page_image, page_xywh)
         border_points = points_from_polygon(border_polygon)
-        brd = BorderType(Coords=CoordsType(border_points))
-        page.set_Border(brd)
+        page.set_Border(BorderType(Coords=CoordsType(border_points)))
 
-        page_image = crop_image(page_image, box=(min_x, min_y, max_x, max_y))
+        page_image = crop_image(page_image, box=(left, top, right, bottom))
         page_xywh['features'] += ',cropped'
 
         file_id = make_file_id(input_file, self.output_file_grp)
-
         file_path = self.workspace.save_image_file(page_image,
                                                    file_id + '-IMG',
-                                                   page_id=page_id,
+                                                   page_id=input_file.pageId,
                                                    file_grp=self.output_file_grp)
         page.add_AlternativeImage(AlternativeImageType(
             filename=file_path, comments=page_xywh['features']))

--- a/ocrd_anybaseocr/ocrd-tool.json
+++ b/ocrd_anybaseocr/ocrd-tool.json
@@ -54,7 +54,6 @@
       "input_file_grp": ["OCR-D-IMG-DESKEW"],
       "output_file_grp": ["OCR-D-IMG-CROP"],
       "parameters": {
-        "force"       :  {"type":"boolean",                      "default":true, "description": "overwrite existing files"},
         "colSeparator":  {"type": "number", "format": "float", "default": 0.04, "description": "consider space between column. 25% of width"},
         "maxRularArea":  {"type": "number", "format": "float", "default": 0.3, "description": "Consider maximum rular area"},
         "minArea":       {"type": "number", "format": "float", "default": 0.05, "description": "rular position in below"},
@@ -65,7 +64,7 @@
         "rularRatioMax": {"type": "number", "format": "float", "default": 10.0, "description": "rular position in below"},
         "rularRatioMin": {"type": "number", "format": "float", "default": 3.0, "description": "rular position in below"},
         "rularWidth":    {"type": "number", "format": "float", "default": 0.95, "description": "maximum rular width"},
-        "operation_level": {"type": "string", "enum": ["page"], "default": "page","description": "PAGE XML hierarchy level to operate on"}
+        "padding":       {"type": "number", "format": "integer", "default": 10, "description": "extend resulting border by this many px in each direction"}
       }
     },
     "ocrd-anybaseocr-dewarp": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ keras >= 2.3.0, < 2.4.0
 keras-preprocessing == 1.1.0
 numpy >= 1.15.4
 ocrd >= 2.14.0
-ocrd-fork-ocropy >= 1.4.0a3
+ocrd-fork-ocropy >= 1.4.0a3 # Python3 ocrolib
 ocrd-fork-pylsd >= 0.0.3
 opencv-python-headless >= 3.4
 pandas


### PR DESCRIPTION
Cropping is almost always too tight. The inactive internal print/debug facilities seem to have used 20px horizontal and 40px vertical (which seems rather large). This adds padding – as a parameter with 10px default.

Also contains some basic sanity fixes:
- remove `operation_level` parameter
- remove `force` parameter
- fix setting pageId of derived images

The code is in pretty bad shape, with bad English and virtually no documentation. I'll probably address this in a separate PR.