### PR TITLE
dewarp: fix generated image file ID

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,7 @@ jobs:
             pip install --upgrade pip
             pip install -r requirements.test.txt
             pip install -r requirements.txt
+            apt-get install imagemagick
             make models
       - save_cache:
           paths:


### PR DESCRIPTION
Fixes a bug when on page level there is no PcGtsId and therefore the `@imageFilename` path is used to concat the new derived image file ID – but IDs must not contain `/`.