### PR TITLE
Dockerfile resources

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,13 @@ COPY README.md .
 RUN pip install . \
 	&& rm -rf /build/ocrd_anybaseocr
 
+RUN ocrd resmgr download -l system ocrd-anybaseocr-layout-analysis mapping_densenet.pickle && \
+    ocrd resmgr download -l system ocrd-anybaseocr-layout-analysis structure_analysis && \
+    ocrd resmgr download -l system ocrd-anybaseocr-dewarp latest_net_G.pth && \
+    ocrd resmgr download -l system ocrd-anybaseocr-tiseg seg_model  && \
+    ocrd resmgr download -l system ocrd-anybaseocr-block-segmentation  block_segmentation_weights.h5  && \
+    # clean possibly created log-files/dirs of ocrd_network logger to prevent permission problems
+    rm -rf /tmp/ocrd_*
+
 WORKDIR /data
 VOLUME ["/data"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,18 @@
-FROM ocrd/core-cuda-tf2:v2.70.0 AS base
+ARG DOCKER_BASE_IMAGE
+FROM $DOCKER_BASE_IMAGE
 ARG VCS_REF
 ARG BUILD_DATE
 LABEL \
-    maintainer="https://github.com/OCR-D/ocrd_anybaseocr/issues" \
+    maintainer="https://ocr-d.de/kontakt" \
     org.label-schema.vcs-ref=$VCS_REF \
+    org.label-schema.build-date=$BUILD_DATE \
     org.label-schema.vcs-url="https://github.com/OCR-D/ocrd_anybaseocr" \
-    org.label-schema.build-date=$BUILD_DATE
+    org.opencontainers.image.vendor="DFG-Funded Initiative for Optical Character Recognition Development" \
+    org.opencontainers.image.title="ocrd_anybaseocr" \
+    org.opencontainers.image.source="https://github.com/OCR-D/ocrd_anybaseocr" \
+    org.opencontainers.image.documentation="https://github.com/OCR-D/ocrd_anybaseocr/blob/${VCS_REF}/README.md" \
+    org.opencontainers.image.revision=$VCS_REF \
+    org.opencontainers.image.created=$BUILD_DATE
 
 WORKDIR /build/ocrd_anybaseocr
 COPY setup.py .

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ TESTS=tests
 
 # Tag to publish docker image to
 DOCKER_TAG = ocrd/anybaseocr
+DOCKER_BASE_IMAGE = docker.io/ocrd/core-cuda-tf2:v2.70.0
 
 # BEGIN-EVAL makefile-parser --make-help Makefile
 
@@ -72,7 +73,8 @@ models:
 
 .PHONY: docker
 docker:
-	docker build \
+	docker build --debug \
+	--build-arg DOCKER_BASE_IMAGE=$(DOCKER_BASE_IMAGE) \
 	--build-arg VCS_REF=$$(git rev-parse --short HEAD) \
 	--build-arg BUILD_DATE=$$(date -u +"%Y-%m-%dT%H:%M:%SZ") \
 	-t '$(DOCKER_TAG)' .


### PR DESCRIPTION
The ocrd-network workers of ocrd-anybaseocr currently fail to start with an error like the following: 
```
Traceback (most recent call last):
  File "/usr/local/bin/ocrd-anybaseocr-layout-analysis", line 8, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/ocrd_anybaseocr/cli/ocrd_anybaseocr_layout_analysis.py", line 247, in cli
    return ocrd_cli_wrap_processor(OcrdAnybaseocrLayoutAnalyser, *args, **kwargs)
  File "/build/core/build/__editable__.ocrd-2.70.0-py3-none-any/ocrd/decorators/__init__.py", line 68, in ocrd_cli_wrap_processor
    check_and_run_network_agent(processorClass, subcommand, address, database, queue)
  File "/build/core/build/__editable__.ocrd-2.70.0-py3-none-any/ocrd/decorators/__init__.py", line 184, in check_and_run_network_agent
    processor = ProcessorClass(workspace=None)
  File "/usr/local/lib/python3.8/site-packages/ocrd_anybaseocr/cli/ocrd_anybaseocr_layout_analysis.py", line 67, in __init__
    self.setup()
  File "/usr/local/lib/python3.8/site-packages/ocrd_anybaseocr/cli/ocrd_anybaseocr_layout_analysis.py", line 71, in setup
    model_path = Path(self.resolve_resource(self.parameter['model_path']))
  File "/build/core/build/__editable__.ocrd-2.70.0-py3-none-any/ocrd/processor/base.py", line 244, in resolve_resource
    raise ResourceNotFoundError(val, executable)
ocrd.processor.base.ResourceNotFoundError: Could not find resource 'structure_analysis' for executable 'ocrd-anybaseocr-layout-analysis'. Try 'ocrd resmgr download ocrd-anybaseocr-layout-analysis structure_analysis' to download this resource.
``` 

Because of that I added the resource-downloading to solve this error.

But I'm not sure if all the resources I added are strictly necessary though, because the worker for example `ocrd-anybaseocr-block-segmentation` seems to start without is (though still failing later because of `tenserflow.keras.__version__` already mentionend in #107 )